### PR TITLE
Fix throttled requests

### DIFF
--- a/src/Layers/ThrottleLayer.lua
+++ b/src/Layers/ThrottleLayer.lua
@@ -27,7 +27,8 @@ function ThrottleLayer._perform(methodName, collectionName, ...)
 	if ThrottleLayer._queue[resource] == nil then
 		ThrottleLayer._queue[resource] = {}
 
-		Promise.defer(function(resolve)
+		coroutine.wrap(function()
+			RunService.Heartbeat:Wait()
 			while #ThrottleLayer._queue[resource] > 0 do
 				local request = table.remove(ThrottleLayer._queue[resource], 1)
 
@@ -47,8 +48,7 @@ function ThrottleLayer._perform(methodName, collectionName, ...)
 			end
 
 			ThrottleLayer._queue[resource] = nil
-			resolve()
-		end)
+		end)()
 	end
 
 	local args = { methodName, collectionName, ... }

--- a/src/Layers/ThrottleLayer.lua
+++ b/src/Layers/ThrottleLayer.lua
@@ -1,4 +1,6 @@
 local DataStoreService = require(script.Parent.Parent.Parent.MockDataStoreService)
+local Promise = require(script.Parent.Parent.Parent.Promise)
+local Error = require(script.Parent.Parent.Error)
 local RunService = game:GetService("RunService")
 
 local DataStoreLayer = require(script.Parent.DataStoreLayer)
@@ -25,24 +27,40 @@ function ThrottleLayer._perform(methodName, collectionName, ...)
 	if ThrottleLayer._queue[resource] == nil then
 		ThrottleLayer._queue[resource] = {}
 
-		local connection
-		connection = RunService.Heartbeat:Connect(function()
-			for _, thread in ipairs(ThrottleLayer._queue[resource]) do
-				if DataStoreService:GetRequestBudgetForRequestType(resource) > 0 then
-					DataStoreLayer.perform(unpack(thread))
+		Promise.defer(function(resolve)
+			while #ThrottleLayer._queue[resource] > 0 do
+				local request = table.remove(ThrottleLayer._queue[resource], 1)
+
+				while DataStoreService:GetRequestBudgetForRequestType(resource) == 0 do
+					RunService.Heartbeat:Wait()
+				end
+
+				local ok, result = pcall(DataStoreLayer.perform, unpack(request.args))
+				if ok then
+					request.resolve(result)
 				else
-					break
+					request.reject(Error.new({
+						kind = Error.Kind.DataStoreError,
+						error = result
+					}))
 				end
 			end
 
-			if #ThrottleLayer._queue[resource] == 0 then
-				connection:Disconnect()
-				ThrottleLayer._queue[resource] = nil
-			end
+			ThrottleLayer._queue[resource] = nil
+			resolve()
 		end)
 	end
 
-	table.insert(ThrottleLayer._queue[resource], { methodName, ... })
+	local args = { methodName, collectionName, ... }
+	local promise = Promise.new(function(resolve, reject)
+		table.insert(ThrottleLayer._queue[resource], {
+			args = args,
+			resolve = resolve,
+			reject = reject
+		})
+	end)
+
+	return promise:expect()
 end
 
 function ThrottleLayer.update(collection, key, callback)


### PR DESCRIPTION
Throttled and queued requests did not return their results. This PR fixes this issue by using Promises to process queued requests.