### PR TITLE
Fix MigrationLayer and DataLayer

### DIFF
--- a/src/Layers/DataLayer/init.lua
+++ b/src/Layers/DataLayer/init.lua
@@ -44,11 +44,20 @@ function DataLayer._pack(value)
 	}
 end
 
--- Todo: Prevent unpacking twice
 function DataLayer.update(collection, key, callback)
-	return DataLayer._unpack(RetryLayer.update(collection, key, function(value)
-		return DataLayer._pack(callback(DataLayer._unpack(value)))
-	end))
+	local decompressed
+
+	RetryLayer.update(collection, key, function(value)
+		decompressed = callback(DataLayer._unpack(value))
+
+		if decompressed ~= nil then
+			return DataLayer._pack(decompressed)
+		else
+			return nil
+		end
+	end)
+
+	return decompressed
 end
 
 function DataLayer.read(collection, key)

--- a/src/Layers/MigrationLayer.lua
+++ b/src/Layers/MigrationLayer.lua
@@ -27,11 +27,20 @@ function MigrationLayer._pack(value, migrations)
 	}
 end
 
--- Todo: Prevent unpacking twice
 function MigrationLayer.update(collection, key, callback, migrations)
-	return MigrationLayer._unpack(DataLayer.update(collection, key, function(value)
-		return MigrationLayer._pack(callback(MigrationLayer._unpack(value, migrations)), migrations)
-	end), migrations)
+	local migrated
+
+	DataLayer.update(collection, key, function(value)
+		migrated = callback(MigrationLayer._unpack(value, migrations))
+
+		if migrated ~= nil then
+			return MigrationLayer._pack(migrated, migrations)
+		else
+			return nil
+		end
+	end)
+
+	return migrated
 end
 
 function MigrationLayer.read(collection, key, migrations)


### PR DESCRIPTION
This PR does two things to the ``MigrationLayer`` and the ``DataLayer``.

First, it only unpacks the data once. Before it was unpacking the data twice.

Second, it returns nil when its ``callback`` returns ``nil``. This is important, because the ``LockSession`` returns ``nil`` when it can not acquire a lock. Before this change, when you loaded a ``Document`` that was session locked, it would still update over, because the ``MigrationLayer`` and ``DataLayer`` weren't returning ``nil``.