### PR TITLE
Fix promise logic

### DIFF
--- a/src/Collection.lua
+++ b/src/Collection.lua
@@ -54,15 +54,13 @@ function Collection:getDocument(name)
 
 	if self._activeDocuments[name] == nil then
 		self._activeDocuments[name] = Document.new(self, name)
+
+		self._activeDocuments[name]:readyPromise():catch(function()
+			self._activeDocuments[name] = nil
+		end)
 	end
 
-	local promise = self._activeDocuments[name]:readyPromise()
-
-	promise:catch(function()
-		self._activeDocuments[name] = nil
-	end)
-
-	return promise
+	return self._activeDocuments[name]:readyPromise()
 end
 
 function Collection:getLatestMigrationVersion()


### PR DESCRIPTION
This PR fixes 2 issues with how the `document:readyPromise()` was handled by `Collection`. The first issue was that it would call `promise:catch()` every time where as this PR only calls it the first time.

The 2nd issue it fixes is more important. Since the promise that is catched and returned is the same (the first time), if the user cancels that promise, catch will no longer fire if there is an error. To fix it, we just return a unique promise from the one we called catch on.